### PR TITLE
Link experiment plots to PubMed IDs

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -42,4 +42,5 @@
     color: #d1d5db;
     white-space: nowrap;
     padding: 0 0.5rem;
+    text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- Load `exp_config.json` to map experiments to PubMed IDs and titles
- Make experiment names in plots clickable links to their PubMed pages
- Display experiment titles within tooltips and ensure chart labels have no underline

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae40674208331bc10c34ca8e1ed6b