### PR TITLE
Add QC swarm plot visualization

### DIFF
--- a/css/qc.css
+++ b/css/qc.css
@@ -1,0 +1,10 @@
+.swarm-container {
+    position: relative;
+    width: 100%;
+    height: 256px; /* Tailwind h-64 equivalent */
+}
+
+.axis path,
+.axis line {
+    stroke: #4b5563; /* gray-600 */
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/silent.css">
     <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/qc.css">
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -64,6 +65,7 @@
         <nav class="flex justify-center gap-6 mb-8">
             <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
             <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
+            <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC</a>
         </nav>
 
         <!-- Page 1: Silent VSG Leaderboard -->
@@ -108,6 +110,29 @@
                 </div>
             </div>
         </div>
+
+        <!-- Page 3: QC Swarm Plots -->
+        <div id="page-qc" class="page-container">
+            <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-blue-400">
+                    QC Distributions
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Main VSG% and Mito%</p>
+            </header>
+            <div class="mb-10">
+                <h2 class="text-center text-xl font-semibold mb-4">Main VSG %</h2>
+                <div class="swarm-container">
+                    <svg id="qc-main" class="w-full h-64"></svg>
+                </div>
+            </div>
+            <div class="mb-10">
+                <h2 class="text-center text-xl font-semibold mb-4">Mito %</h2>
+                <div class="swarm-container">
+                    <svg id="qc-mito" class="w-full h-64"></svg>
+                </div>
+            </div>
+        </div>
+
         <div id="loader" class="text-center py-10"><p class="text-gray-400">Loading data...</p></div>
     </div>
 
@@ -116,5 +141,7 @@
     <script src="js/common.js"></script>
     <script src="js/silent.js"></script>
     <script src="js/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+    <script src="js/qc.js"></script>
 </body>
 </html>

--- a/js/common.js
+++ b/js/common.js
@@ -1,21 +1,18 @@
 document.addEventListener('DOMContentLoaded', () => {
     const navSilent = document.getElementById('nav-silent');
     const navMain = document.getElementById('nav-main');
+    const navQC = document.getElementById('nav-qc');
     const pageSilent = document.getElementById('page-silent');
     const pageMain = document.getElementById('page-main');
+    const pageQC = document.getElementById('page-qc');
 
     function switchPage(page) {
-        if (page === 'silent') {
-            pageSilent.classList.add('active');
-            pageMain.classList.remove('active');
-            navSilent.classList.add('active');
-            navMain.classList.remove('active');
-        } else {
-            pageSilent.classList.remove('active');
-            pageMain.classList.add('active');
-            navSilent.classList.remove('active');
-            navMain.classList.add('active');
-        }
+        pageSilent.classList.toggle('active', page === 'silent');
+        pageMain.classList.toggle('active', page === 'main');
+        pageQC.classList.toggle('active', page === 'qc');
+        navSilent.classList.toggle('active', page === 'silent');
+        navMain.classList.toggle('active', page === 'main');
+        navQC.classList.toggle('active', page === 'qc');
     }
 
     navSilent.addEventListener('click', (e) => {
@@ -26,5 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
     navMain.addEventListener('click', (e) => {
         e.preventDefault();
         switchPage('main');
+    });
+
+    navQC.addEventListener('click', (e) => {
+        e.preventDefault();
+        switchPage('qc');
     });
 });

--- a/js/qc.js
+++ b/js/qc.js
@@ -1,0 +1,79 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const tooltip = document.getElementById('tooltip');
+    const loader = document.getElementById('loader');
+
+    async function initQC() {
+        try {
+            const response = await fetch('data/QC.csv');
+            const text = await response.text();
+            const data = d3.csvParse(text, d => ({
+                experiment: d.experiment,
+                Main_VSG_perc: +d.Main_VSG_perc,
+                Mito_perc: +d.Mito_perc
+            }));
+            renderSwarm(data, 'Main_VSG_perc', '#qc-main');
+            renderSwarm(data, 'Mito_perc', '#qc-mito');
+        } catch (err) {
+            console.error('Failed to load QC CSV', err);
+        } finally {
+            if (loader) loader.style.display = 'none';
+        }
+    }
+
+    function renderSwarm(data, column, selector) {
+        const svg = d3.select(selector);
+        const width = svg.node().getBoundingClientRect().width;
+        const height = svg.node().getBoundingClientRect().height;
+        const margin = { top: 10, right: 20, bottom: 30, left: 20 };
+
+        const swarmData = data.map(d => ({ ...d }));
+
+        const x = d3.scaleLinear()
+            .domain([0, d3.max(swarmData, d => d[column])]).nice()
+            .range([margin.left, width - margin.right]);
+
+        const yCenter = (height - margin.top - margin.bottom) / 2 + margin.top;
+
+        const simulation = d3.forceSimulation(swarmData)
+            .force('x', d3.forceX(d => x(d[column])).strength(1))
+            .force('y', d3.forceY(yCenter))
+            .force('collide', d3.forceCollide(4))
+            .stop();
+
+        for (let i = 0; i < 250; ++i) simulation.tick();
+
+        svg.attr('width', width).attr('height', height);
+
+        svg.append('g')
+            .attr('transform', `translate(0,${height - margin.bottom})`)
+            .attr('class', 'axis')
+            .call(d3.axisBottom(x).ticks(6))
+            .selectAll('text')
+            .attr('fill', '#d1d5db');
+
+        svg.selectAll('.axis path, .axis line').attr('stroke', '#4b5563');
+
+        svg.append('g')
+            .selectAll('circle')
+            .data(swarmData)
+            .enter()
+            .append('circle')
+            .attr('cx', d => d.x)
+            .attr('cy', d => d.y)
+            .attr('r', 4)
+            .attr('fill', '#4f46e5')
+            .on('mouseover', (event, d) => {
+                tooltip.style.display = 'block';
+                tooltip.innerHTML = `<strong>${d.experiment}</strong>`;
+            })
+            .on('mouseout', () => {
+                tooltip.style.display = 'none';
+            })
+            .on('mousemove', (event) => {
+                tooltip.style.left = `${event.clientX + 15}px`;
+                tooltip.style.top = `${event.clientY + 15}px`;
+            });
+    }
+
+    initQC();
+});


### PR DESCRIPTION
## Summary
- add QC nav page and container with two swarm plot placeholders
- implement QC swarm plots for Main_VSG_perc and Mito_perc with tooltips
- update navigation logic and styles for new page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae6e1369c833183a46ee548d9bee5