### PR TITLE
Add QC leaderboard visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
         <nav class="flex justify-center gap-6 mb-8">
             <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
             <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
+            <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a>
         </nav>
 
         <!-- Page 1: Silent VSG Leaderboard -->
@@ -108,6 +109,22 @@
                 </div>
             </div>
         </div>
+
+        <!-- Page 3: QC Leaderboard -->
+        <div id="page-qc" class="page-container">
+            <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-blue-400">
+                    QC Visualization
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Interactive Leaderboard</p>
+            </header>
+            <div id="filters-qc" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
+                <button data-sort="Main_VSG_perc" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Main VSG %</button>
+                <button data-sort="Mito_perc" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Mito %</button>
+            </div>
+            <div id="qc-leaderboard" class="relative w-full mx-auto max-w-4xl"></div>
+            <div id="qc-expander" class="text-center mt-6"></div>
+        </div>
         <div id="loader" class="text-center py-10"><p class="text-gray-400">Loading data...</p></div>
     </div>
 
@@ -116,5 +133,6 @@
     <script src="js/common.js"></script>
     <script src="js/silent.js"></script>
     <script src="js/main.js"></script>
+    <script src="js/qc.js"></script>
 </body>
 </html>

--- a/js/common.js
+++ b/js/common.js
@@ -1,20 +1,23 @@
 document.addEventListener('DOMContentLoaded', () => {
     const navSilent = document.getElementById('nav-silent');
     const navMain = document.getElementById('nav-main');
+    const navQC = document.getElementById('nav-qc');
     const pageSilent = document.getElementById('page-silent');
     const pageMain = document.getElementById('page-main');
+    const pageQC = document.getElementById('page-qc');
 
     function switchPage(page) {
+        [pageSilent, pageMain, pageQC].forEach(p => p.classList.remove('active'));
+        [navSilent, navMain, navQC].forEach(n => n.classList.remove('active'));
         if (page === 'silent') {
             pageSilent.classList.add('active');
-            pageMain.classList.remove('active');
             navSilent.classList.add('active');
-            navMain.classList.remove('active');
-        } else {
-            pageSilent.classList.remove('active');
+        } else if (page === 'main') {
             pageMain.classList.add('active');
-            navSilent.classList.remove('active');
             navMain.classList.add('active');
+        } else if (page === 'qc') {
+            pageQC.classList.add('active');
+            navQC.classList.add('active');
         }
     }
 
@@ -26,5 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
     navMain.addEventListener('click', (e) => {
         e.preventDefault();
         switchPage('main');
+    });
+
+    navQC.addEventListener('click', (e) => {
+        e.preventDefault();
+        switchPage('qc');
     });
 });

--- a/js/qc.js
+++ b/js/qc.js
@@ -1,0 +1,131 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const loader = document.getElementById('loader');
+    const tooltip = document.getElementById('tooltip');
+    const leaderboardContainer = document.getElementById('qc-leaderboard');
+    const filtersQC = document.getElementById('filters-qc');
+    const expanderContainer = document.getElementById('qc-expander');
+    let qcData = [], currentSort = 'Main_VSG_perc', isExpanded = false, expConfig = {};
+    const itemHeight = 76, displayLimit = 20;
+
+    async function initQC() {
+        try {
+            const [csvResp, configResp] = await Promise.all([
+                fetch('data/QC.csv'),
+                fetch('data/exp_config.json')
+            ]);
+            const csv = await csvResp.text();
+            expConfig = await configResp.json();
+            parseQCData(csv);
+            createLeaderboardItems();
+            renderLeaderboard();
+            setupFilters();
+        } catch (err) {
+            console.error('Failed to load QC CSV', err);
+        } finally {
+            if (loader) loader.style.display = 'none';
+        }
+    }
+
+    function parseQCData(csv) {
+        const lines = csv.trim().split('\n');
+        qcData = lines.slice(1).map(line => {
+            const parts = line.split(',');
+            return {
+                Experiment: parts[1].trim(),
+                Main_VSG_perc: parseFloat(parts[2]) || 0,
+                Mito_perc: parseFloat(parts[3]) || 0
+            };
+        }).filter(d => d.Experiment);
+    }
+
+    function createLeaderboardItems() {
+        qcData.forEach(item => {
+            const li = document.createElement('div');
+            li.className = 'leaderboard-item flex items-center p-3 bg-gray-800 rounded-lg shadow-md my-2';
+            li.dataset.experiment = item.Experiment;
+            li.innerHTML = `
+                <div class="rank-badge w-10 h-10 flex-shrink-0 items-center justify-center rounded-full bg-gray-700 font-bold text-lg mr-4 flex">
+                    <span class="rank-text"></span>
+                </div>
+                <div class="flex-grow overflow-hidden">
+                    <a class="font-semibold text-white truncate" target="_blank" rel="noopener">${item.Experiment}</a>
+                    <div class="w-full bg-black/30 rounded-full h-2.5 mt-1 overflow-hidden">
+                        <div class="bar bg-gradient-to-r from-green-500 to-blue-500 h-2.5 rounded-full" style="width: 0%; transition: width 0.6s ease;"></div>
+                    </div>
+                </div>`;
+            const link = li.querySelector('a');
+            const config = expConfig[item.Experiment] || {};
+            if (config.pubmed_id) {
+                link.href = `https://pubmed.ncbi.nlm.nih.gov/${config.pubmed_id}/`;
+            } else {
+                link.removeAttribute('href');
+            }
+            li.addEventListener('mouseover', () => {
+                tooltip.style.display = 'block';
+                const value = item[currentSort];
+                const title = config.title ? `${config.title}<br>` : '';
+                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}${currentSort}: ${(value * 100).toFixed(2)}%`;
+            });
+            li.addEventListener('mouseout', () => {
+                tooltip.style.display = 'none';
+            });
+            li.addEventListener('mousemove', (e) => {
+                tooltip.style.left = `${e.clientX + 15}px`;
+                tooltip.style.top = `${e.clientY + 15}px`;
+            });
+            leaderboardContainer.appendChild(li);
+        });
+    }
+
+    function renderLeaderboard() {
+        qcData.sort((a, b) => b[currentSort] - a[currentSort]);
+        const count = isExpanded ? qcData.length : Math.min(displayLimit, qcData.length);
+        leaderboardContainer.style.height = `${count * itemHeight}px`;
+        const maxVal = qcData.length > 0 ? qcData[0][currentSort] : 1;
+        qcData.forEach((item, index) => {
+            const el = leaderboardContainer.querySelector(`[data-experiment="${item.Experiment}"]`);
+            if (!el) return;
+            el.style.transform = `translateY(${index * itemHeight}px)`;
+            el.style.opacity = index < count ? '1' : '0';
+            el.style.pointerEvents = index < count ? 'auto' : 'none';
+            const rank = index + 1;
+            const rankBadge = el.querySelector('.rank-badge');
+            rankBadge.classList.remove('rank-1', 'rank-2', 'rank-3');
+            if (rank <= 3) rankBadge.classList.add(`rank-${rank}`);
+            el.querySelector('.rank-text').textContent = rank;
+            const bar = el.querySelector('.bar');
+            bar.style.width = `${maxVal > 0 ? (item[currentSort] / maxVal) * 100 : 0}%`;
+            if (currentSort === 'Main_VSG_perc') {
+                bar.className = 'bar bg-gradient-to-r from-green-500 to-blue-500 h-2.5 rounded-full';
+            } else {
+                bar.className = 'bar bg-gradient-to-r from-pink-500 to-yellow-500 h-2.5 rounded-full';
+            }
+        });
+    }
+
+    function setupFilters() {
+        filtersQC.addEventListener('click', (e) => {
+            if (e.target.tagName === 'BUTTON') {
+                currentSort = e.target.dataset.sort;
+                filtersQC.querySelector('.active').classList.remove('active');
+                e.target.classList.add('active');
+                renderLeaderboard();
+            }
+        });
+
+        if (qcData.length > displayLimit) {
+            const btn = document.createElement('button');
+            btn.className = 'filter-btn font-semibold py-2 px-5 rounded-full bg-gray-700 hover:bg-gray-600';
+            btn.textContent = `Show All (${qcData.length})`;
+            expanderContainer.appendChild(btn);
+            btn.addEventListener('click', () => {
+                isExpanded = !isExpanded;
+                btn.textContent = isExpanded ? 'Show Less' : `Show All (${qcData.length})`;
+                renderLeaderboard();
+            });
+        }
+    }
+
+    initQC();
+});
+


### PR DESCRIPTION
## Summary
- Add QC leaderboard page that reads `QC.csv` and displays Main VSG and Mito percentages.
- Integrate new QC page into navigation and shared page-switching logic.
- Implement interactive sorting and tooltip functionality for QC data.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baec49254883319e9ca6bcc8dd5a11