### PR TITLE
Add landing page with dataset statistics

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>T. brucei VSG Modulation</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/silent.css">
+    <link rel="stylesheet" href="css/main.css">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #111827; /* bg-gray-900 */
+        }
+        /* --- General & Nav --- */
+        .nav-link {
+            transition: all 0.3s ease;
+            border-bottom: 2px solid transparent;
+        }
+        .nav-link.active {
+            border-bottom-color: #4f46e5; /* indigo-600 */
+            color: #e5e7eb; /* gray-200 */
+        }
+        .filter-btn {
+            transition: all 0.3s ease;
+        }
+        .filter-btn.active {
+            background-color: #4f46e5; /* bg-indigo-600 */
+            color: white;
+            box-shadow: 0 4px 14px 0 rgba(79, 70, 229, 0.39);
+        }
+        .page-container {
+            display: none; /* Hidden by default */
+        }
+        .page-container.active {
+            display: block; /* Shown when active */
+        }
+        #tooltip {
+            position: fixed;
+            display: none;
+            background-color: rgba(17, 24, 39, 0.8); /* bg-gray-900 with opacity */
+            backdrop-filter: blur(4px);
+            color: white;
+            padding: 0.5rem 0.75rem;
+            border-radius: 0.5rem; /* rounded-lg */
+            font-size: 0.875rem; /* text-sm */
+            pointer-events: none; /* Allows mouse events to pass through */
+            z-index: 100;
+            transition: opacity 0.2s;
+            border: 1px solid rgba(75, 85, 99, 0.5);
+        }
+
+        /* Visualization-specific styles moved to external CSS files */
+    </style>
+</head>
+<body class="text-white antialiased">
+
+    <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-5xl">
+        
+        <!-- Navigation -->
+        <nav class="flex justify-center gap-6 mb-8">
+            <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
+            <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
+            <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a>
+        </nav>
+
+        <!-- Page 1: Silent VSG Leaderboard -->
+        <div id="page-silent" class="page-container active">
+            <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400">
+                    Trypanosoma Brucei Silent VSGs Modulation
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Interactive Leaderboard</p>
+            </header>
+            <div id="filters-silent" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
+                <button data-sort="sum" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Overall Impact (Sum)</button>
+                <button data-sort="BES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">BES</button>
+                <button data-sort="MC" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MC</button>
+                <button data-sort="MES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MES</button>
+                <button data-sort="array" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Array</button>
+            </div>
+            <div id="leaderboard-container" class="relative w-full mx-auto max-w-4xl"></div>
+            <div id="expander-container" class="text-center mt-6"></div>
+        </div>
+
+        <!-- Page 2: Main VSG Diverging Chart -->
+        <div id="page-main" class="page-container">
+             <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500">
+                    Main VSG Modulation
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Up-regulation vs. Down-regulation</p>
+            </header>
+            <div id="filters-main" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
+                <button data-sort="magnitude" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Biggest Changes</button>
+                <button data-sort="up" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Top Up-regulated</button>
+                <button data-sort="down" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Top Down-regulated</button>
+            </div>
+            <div class="relative w-full bg-gray-800/50 rounded-lg p-4 sm:p-6">
+                <div class="flex justify-between text-xs text-gray-400 mb-2 px-2">
+                    <span>Down-regulated</span>
+                    <span>Up-regulated</span>
+                </div>
+                <div id="chart-container" class="relative w-full">
+                    <div class="center-axis"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Page 3: QC Leaderboard -->
+        <div id="page-qc" class="page-container">
+            <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-blue-400">
+                    QC Visualization
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Interactive Leaderboard</p>
+            </header>
+            <div id="filters-qc" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
+                <button data-sort="Main_VSG_perc" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Main VSG %</button>
+                <button data-sort="Mito_perc" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Mito %</button>
+            </div>
+            <div id="qc-leaderboard" class="relative w-full mx-auto max-w-4xl"></div>
+            <div id="qc-expander" class="text-center mt-6"></div>
+        </div>
+        <div id="loader" class="text-center py-10"><p class="text-gray-400">Loading data...</p></div>
+    </div>
+
+    <div id="tooltip"></div>
+
+    <script src="js/common.js"></script>
+    <script src="js/silent.js"></script>
+    <script src="js/main.js"></script>
+    <script src="js/qc.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,138 +1,49 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>T. brucei VSG Modulation</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/silent.css">
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/main.css" />
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #111827; /* bg-gray-900 */
         }
-        /* --- General & Nav --- */
-        .nav-link {
-            transition: all 0.3s ease;
-            border-bottom: 2px solid transparent;
-        }
-        .nav-link.active {
-            border-bottom-color: #4f46e5; /* indigo-600 */
-            color: #e5e7eb; /* gray-200 */
-        }
-        .filter-btn {
-            transition: all 0.3s ease;
-        }
-        .filter-btn.active {
-            background-color: #4f46e5; /* bg-indigo-600 */
-            color: white;
-            box-shadow: 0 4px 14px 0 rgba(79, 70, 229, 0.39);
-        }
-        .page-container {
-            display: none; /* Hidden by default */
-        }
-        .page-container.active {
-            display: block; /* Shown when active */
-        }
-        #tooltip {
-            position: fixed;
-            display: none;
-            background-color: rgba(17, 24, 39, 0.8); /* bg-gray-900 with opacity */
-            backdrop-filter: blur(4px);
-            color: white;
-            padding: 0.5rem 0.75rem;
-            border-radius: 0.5rem; /* rounded-lg */
-            font-size: 0.875rem; /* text-sm */
-            pointer-events: none; /* Allows mouse events to pass through */
-            z-index: 100;
-            transition: opacity 0.2s;
-            border: 1px solid rgba(75, 85, 99, 0.5);
-        }
-
-        /* Visualization-specific styles moved to external CSS files */
     </style>
 </head>
-<body class="text-white antialiased">
-
-    <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-5xl">
-        
-        <!-- Navigation -->
-        <nav class="flex justify-center gap-6 mb-8">
-            <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
-            <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
-            <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a>
-        </nav>
-
-        <!-- Page 1: Silent VSG Leaderboard -->
-        <div id="page-silent" class="page-container active">
-            <header class="text-center mb-8">
-                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400">
-                    Trypanosoma Brucei Silent VSGs Modulation
-                </h1>
-                <p class="mt-2 text-lg text-gray-400">Interactive Leaderboard</p>
-            </header>
-            <div id="filters-silent" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
-                <button data-sort="sum" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Overall Impact (Sum)</button>
-                <button data-sort="BES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">BES</button>
-                <button data-sort="MC" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MC</button>
-                <button data-sort="MES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MES</button>
-                <button data-sort="array" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Array</button>
-            </div>
-            <div id="leaderboard-container" class="relative w-full mx-auto max-w-4xl"></div>
-            <div id="expander-container" class="text-center mt-6"></div>
+<body class="bg-gray-900 text-white">
+    <div class="container mx-auto px-4 py-16 max-w-3xl text-center">
+        <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400 mb-6">
+            Trypanosoma brucei Silent VSGs Modulation
+        </h1>
+        <p class="text-lg text-gray-300 mb-8">
+            This site presents the visualization layer for a meta-analysis of RNA-seq datasets examining
+            <span class="font-semibold">variant surface glycoprotein (VSG) deregulation</span> in
+            <em>Trypanosoma brucei</em>.
+        </p>
+        <p class="text-gray-300 mb-10">
+            Hundreds of publicly available RNA-seq experiments were reanalyzed in a unified Snakemake-based framework to address two central questions:
+        </p>
+        <ul class="text-left text-gray-300 mb-10 list-disc list-inside">
+            <li>Which experimental factors alter the expression of silent VSGs?</li>
+            <li>Which perturbations decrease expression of the active VSG?</li>
+        </ul>
+        <p class="text-gray-300 mb-12">
+            By processing all datasets through a common pipeline, we also extracted quality control (QC) metrics that can be used to benchmark future experiments.
+        </p>
+        <div class="mb-12">
+            <h2 class="text-2xl font-semibold mb-4">Meta-analysis at a Glance</h2>
+            <ul id="stats" class="text-gray-300 space-y-2"></ul>
         </div>
-
-        <!-- Page 2: Main VSG Diverging Chart -->
-        <div id="page-main" class="page-container">
-             <header class="text-center mb-8">
-                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500">
-                    Main VSG Modulation
-                </h1>
-                <p class="mt-2 text-lg text-gray-400">Up-regulation vs. Down-regulation</p>
-            </header>
-            <div id="filters-main" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
-                <button data-sort="magnitude" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Biggest Changes</button>
-                <button data-sort="up" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Top Up-regulated</button>
-                <button data-sort="down" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Top Down-regulated</button>
-            </div>
-            <div class="relative w-full bg-gray-800/50 rounded-lg p-4 sm:p-6">
-                <div class="flex justify-between text-xs text-gray-400 mb-2 px-2">
-                    <span>Down-regulated</span>
-                    <span>Up-regulated</span>
-                </div>
-                <div id="chart-container" class="relative w-full">
-                    <div class="center-axis"></div>
-                </div>
-            </div>
+        <div class="flex flex-col sm:flex-row justify-center gap-4">
+            <a href="dashboard.html#silent" class="px-6 py-3 bg-indigo-600 hover:bg-indigo-500 rounded-lg font-semibold">Silent VSG Leaderboard</a>
+            <a href="dashboard.html#qc" class="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold">QC Leaderboard</a>
         </div>
-
-        <!-- Page 3: QC Leaderboard -->
-        <div id="page-qc" class="page-container">
-            <header class="text-center mb-8">
-                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-blue-400">
-                    QC Visualization
-                </h1>
-                <p class="mt-2 text-lg text-gray-400">Interactive Leaderboard</p>
-            </header>
-            <div id="filters-qc" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
-                <button data-sort="Main_VSG_perc" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Main VSG %</button>
-                <button data-sort="Mito_perc" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Mito %</button>
-            </div>
-            <div id="qc-leaderboard" class="relative w-full mx-auto max-w-4xl"></div>
-            <div id="qc-expander" class="text-center mt-6"></div>
-        </div>
-        <div id="loader" class="text-center py-10"><p class="text-gray-400">Loading data...</p></div>
     </div>
-
-    <div id="tooltip"></div>
-
-    <script src="js/common.js"></script>
-    <script src="js/silent.js"></script>
-    <script src="js/main.js"></script>
-    <script src="js/qc.js"></script>
+    <script src="js/landing.js"></script>
 </body>
 </html>

--- a/js/common.js
+++ b/js/common.js
@@ -21,18 +21,30 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function handleHash() {
+        const hash = window.location.hash.replace('#', '');
+        if (['silent', 'main', 'qc'].includes(hash)) {
+            switchPage(hash);
+        } else {
+            switchPage('silent');
+        }
+    }
+
     navSilent.addEventListener('click', (e) => {
         e.preventDefault();
-        switchPage('silent');
+        window.location.hash = 'silent';
     });
 
     navMain.addEventListener('click', (e) => {
         e.preventDefault();
-        switchPage('main');
+        window.location.hash = 'main';
     });
 
     navQC.addEventListener('click', (e) => {
         e.preventDefault();
-        switchPage('qc');
+        window.location.hash = 'qc';
     });
+
+    window.addEventListener('hashchange', handleHash);
+    handleHash();
 });

--- a/js/landing.js
+++ b/js/landing.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const statsEl = document.getElementById('stats');
+    try {
+        const response = await fetch('data/exp_config.json');
+        const expConfig = await response.json();
+        const papers = new Set();
+        const factors = new Set();
+        let runCount = 0;
+        const readTypes = {};
+        Object.keys(expConfig).forEach(key => {
+            const exp = expConfig[key];
+            papers.add(exp.pubmed_id);
+            factors.add(key.split('_')[0]);
+            runCount += (exp.controls ? exp.controls.length : 0) +
+                        (exp.treatments ? exp.treatments.length : 0);
+            const type = exp.fastq_type || 'unknown';
+            readTypes[type] = (readTypes[type] || 0) + 1;
+        });
+        const readTypeText = Object.entries(readTypes)
+            .map(([type, count]) => `${count} ${type}`)
+            .join(', ');
+        statsEl.innerHTML = `
+            <li><span class="font-bold">${papers.size}</span> papers</li>
+            <li><span class="font-bold">${factors.size}</span> factors</li>
+            <li><span class="font-bold">${runCount}</span> run accession numbers</li>
+            <li><span class="font-bold">${readTypeText}</span> read type</li>`;
+    } catch (err) {
+        statsEl.innerHTML = '<li class="text-red-400">Failed to load statistics.</li>';
+        console.error(err);
+    }
+});


### PR DESCRIPTION
## Summary
- Add dedicated landing page summarizing the meta-analysis and linking to Silent VSG and QC leaderboards
- Dynamically compute paper, factor, run, and read type statistics from `exp_config.json`
- Support hash-based navigation in the dashboard for direct linking from landing page

## Testing
- `python -m json.tool data/exp_config.json | head -n 20`
- `python - <<'PY'
import json
from collections import Counter
config=json.load(open('data/exp_config.json'))
papers={v['pubmed_id'] for v in config.values()}
factors={k.split('_')[0] for k in config}
run_count=sum(len(v.get('controls',[]))+len(v.get('treatments',[])) for v in config.values())
read_types=Counter(v.get('fastq_type','unknown') for v in config.values())
print('papers', len(papers))
print('factors', len(factors))
print('runs', run_count)
print('read_types', dict(read_types))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68beab9268188331bcdd44831bf958b9