### PR TITLE
Add experiment config table visualization

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -52,3 +52,13 @@ textarea {
     padding: 0 0.5rem;
     text-decoration: none;
 }
+
+.datatable-input {
+    padding: 6px 12px;
+    color: blue;
+}
+
+.datatable-selector {
+    padding: 6px;
+    color: blue;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,11 @@
+button,
+input,
+optgroup,
+select,
+textarea {
+    color: black;
+}
+
 #chart-container {
     transition: height 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -54,6 +54,16 @@
             border: 1px solid rgba(75, 85, 99, 0.5);
         }
 
+        /* Simple-DataTables dark theme overrides */
+        .dataTable-dropdown label {
+            color: #d1d5db; /* gray-300 */
+        }
+        .dataTable-dropdown .dataTable-selector {
+            color: #e5e7eb; /* gray-200 */
+            background-color: #1f2937; /* gray-800 */
+            border: 1px solid #4b5563; /* gray-600 */
+        }
+
         /* Visualization-specific styles moved to external CSS files */
     </style>
 </head>

--- a/dashboard.html
+++ b/dashboard.html
@@ -56,12 +56,16 @@
 
         /* Simple-DataTables dark theme overrides */
         .dataTable-dropdown label {
-            color: #d1d5db; /* gray-300 */
+            color: #d1d5db !important; /* gray-300 */
         }
-        .dataTable-dropdown .dataTable-selector {
-            color: #e5e7eb; /* gray-200 */
-            background-color: #1f2937; /* gray-800 */
-            border: 1px solid #4b5563; /* gray-600 */
+        .dataTable-dropdown .dataTable-selector,
+        .dataTable-search .dataTable-input {
+            color: #e5e7eb !important; /* gray-200 */
+            background-color: #1f2937 !important; /* gray-800 */
+            border: 1px solid #4b5563 !important; /* gray-600 */
+        }
+        .dataTable-search .dataTable-input::placeholder {
+            color: #9ca3af; /* gray-400 */
         }
 
         /* Visualization-specific styles moved to external CSS files */

--- a/dashboard.html
+++ b/dashboard.html
@@ -54,20 +54,6 @@
             border: 1px solid rgba(75, 85, 99, 0.5);
         }
 
-        /* Simple-DataTables dark theme overrides */
-        .dataTable-dropdown label {
-            color: #d1d5db !important; /* gray-300 */
-        }
-        .dataTable-dropdown .dataTable-selector,
-        .dataTable-search .dataTable-input {
-            color: #e5e7eb !important; /* gray-200 */
-            background-color: #1f2937 !important; /* gray-800 */
-            border: 1px solid #4b5563 !important; /* gray-600 */
-        }
-        .dataTable-search .dataTable-input::placeholder {
-            color: #9ca3af; /* gray-400 */
-        }
-
         /* Visualization-specific styles moved to external CSS files */
     </style>
 </head>

--- a/dashboard.html
+++ b/dashboard.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/silent.css">
     <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css">
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -65,6 +66,7 @@
             <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
             <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
             <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a>
+            <a href="#" id="nav-config" class="nav-link text-gray-400 font-medium pb-1">Experiment Config</a>
         </nav>
 
         <!-- Page 1: Silent VSG Leaderboard -->
@@ -122,17 +124,43 @@
                 <button data-sort="Main_VSG_perc" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Main VSG %</button>
                 <button data-sort="Mito_perc" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Mito %</button>
             </div>
-            <div id="qc-leaderboard" class="relative w-full mx-auto max-w-4xl"></div>
-            <div id="qc-expander" class="text-center mt-6"></div>
+        <div id="qc-leaderboard" class="relative w-full mx-auto max-w-4xl"></div>
+        <div id="qc-expander" class="text-center mt-6"></div>
+        </div>
+        
+        <!-- Page 4: Experiment Config Table -->
+        <div id="page-config" class="page-container">
+            <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-400">
+                    Experiment Configuration
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Experiments and SRA Runs</p>
+            </header>
+            <div class="overflow-x-auto">
+                <table id="exp-table" class="min-w-full text-sm text-gray-300">
+                    <thead>
+                        <tr>
+                            <th class="px-4 py-2">Experiment</th>
+                            <th class="px-4 py-2">Type</th>
+                            <th class="px-4 py-2">SRA ID</th>
+                            <th class="px-4 py-2">PubMed ID</th>
+                            <th class="px-4 py-2">Title</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
         </div>
         <div id="loader" class="text-center py-10"><p class="text-gray-400">Loading data...</p></div>
     </div>
 
     <div id="tooltip"></div>
 
+    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" ></script>
     <script src="js/common.js"></script>
     <script src="js/silent.js"></script>
     <script src="js/main.js"></script>
     <script src="js/qc.js"></script>
+    <script src="js/exp_config_table.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
         <div class="flex flex-col sm:flex-row justify-center gap-4">
             <a href="dashboard.html#silent" class="px-6 py-3 bg-indigo-600 hover:bg-indigo-500 rounded-lg font-semibold">Silent VSG Leaderboard</a>
             <a href="dashboard.html#qc" class="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold">QC Leaderboard</a>
+            <a href="dashboard.html#config" class="px-6 py-3 bg-purple-600 hover:bg-purple-500 rounded-lg font-semibold">Experiment Config</a>
         </div>
     </div>
     <script src="js/landing.js"></script>

--- a/js/common.js
+++ b/js/common.js
@@ -2,13 +2,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const navSilent = document.getElementById('nav-silent');
     const navMain = document.getElementById('nav-main');
     const navQC = document.getElementById('nav-qc');
+    const navConfig = document.getElementById('nav-config');
     const pageSilent = document.getElementById('page-silent');
     const pageMain = document.getElementById('page-main');
     const pageQC = document.getElementById('page-qc');
+    const pageConfig = document.getElementById('page-config');
 
     function switchPage(page) {
-        [pageSilent, pageMain, pageQC].forEach(p => p.classList.remove('active'));
-        [navSilent, navMain, navQC].forEach(n => n.classList.remove('active'));
+        [pageSilent, pageMain, pageQC, pageConfig].forEach(p => p.classList.remove('active'));
+        [navSilent, navMain, navQC, navConfig].forEach(n => n.classList.remove('active'));
         if (page === 'silent') {
             pageSilent.classList.add('active');
             navSilent.classList.add('active');
@@ -18,12 +20,15 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (page === 'qc') {
             pageQC.classList.add('active');
             navQC.classList.add('active');
+        } else if (page === 'config') {
+            pageConfig.classList.add('active');
+            navConfig.classList.add('active');
         }
     }
 
     function handleHash() {
         const hash = window.location.hash.replace('#', '');
-        if (['silent', 'main', 'qc'].includes(hash)) {
+        if (['silent', 'main', 'qc', 'config'].includes(hash)) {
             switchPage(hash);
         } else {
             switchPage('silent');
@@ -43,6 +48,11 @@ document.addEventListener('DOMContentLoaded', () => {
     navQC.addEventListener('click', (e) => {
         e.preventDefault();
         window.location.hash = 'qc';
+    });
+
+    navConfig.addEventListener('click', (e) => {
+        e.preventDefault();
+        window.location.hash = 'config';
     });
 
     window.addEventListener('hashchange', handleHash);

--- a/js/exp_config_table.js
+++ b/js/exp_config_table.js
@@ -1,0 +1,32 @@
+// Load experiment configuration and render searchable table
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const table = document.getElementById('exp-table');
+    if (!table) return;
+    try {
+        const resp = await fetch('data/exp_config.json');
+        const config = await resp.json();
+        const tbody = table.querySelector('tbody');
+        Object.entries(config).forEach(([experiment, info]) => {
+            const pub = info.pubmed_id || '';
+            const title = info.title || '';
+            const addRow = (runId, type) => {
+                const pubCell = pub ? `<a href="https://pubmed.ncbi.nlm.nih.gov/${pub}/" target="_blank" class="text-indigo-400 hover:underline">${pub}</a>` : '';
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${experiment}</td>
+                    <td>${type}</td>
+                    <td>${runId}</td>
+                    <td>${pubCell}</td>
+                    <td>${title}</td>
+                `;
+                tbody.appendChild(tr);
+            };
+            (info.controls || []).forEach(run => addRow(run, 'control'));
+            (info.treatments || []).forEach(run => addRow(run, 'treatment'));
+        });
+        new simpleDatatables.DataTable(table);
+    } catch (err) {
+        console.error('Failed to load experiment config', err);
+    }
+});


### PR DESCRIPTION
## Summary
- Add Experiment Config navigation tab and DataTable on dashboard
- Populate table from `exp_config.json` with run IDs, PubMed IDs, and titles
- Extend common navigation script for new page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68becaf928188331aa12b4ef2e12ecd5