### PR TITLE
Add main VSG link and home navigation

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -63,6 +63,7 @@
         
         <!-- Navigation -->
         <nav class="flex justify-center gap-6 mb-8">
+            <a href="index.html" class="nav-link text-gray-400 font-medium pb-1">Home</a>
             <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
             <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
             <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a>

--- a/index.html
+++ b/index.html
@@ -20,21 +20,6 @@
         <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400 mb-6">
             Trypanosoma brucei VSGs Modulation
         </h1>
-        <div class="overflow-x-auto mb-8">
-            <table class="w-full table-auto text-gray-300">
-                <tr>
-                    <td class="px-4 py-2">
-                        <a href="dashboard.html#silent" class="text-indigo-400 hover:underline">Silent VSG Leaderboard</a>
-                    </td>
-                    <td class="px-4 py-2">
-                        <a href="dashboard.html#qc" class="text-green-400 hover:underline">QC Leaderboard</a>
-                    </td>
-                    <td class="px-4 py-2">
-                        <a href="dashboard.html#table" class="text-purple-400 hover:underline">Experiment Table</a>
-                    </td>
-                </tr>
-            </table>
-        </div>
         <p class="text-lg text-gray-300 mb-8">
             This site presents the visualization layer for a meta-analysis of RNA-seq datasets examining
             <span class="font-semibold">variant surface glycoprotein (VSG) deregulation</span> in
@@ -53,6 +38,24 @@
         <div class="mb-12">
             <h2 class="text-2xl font-semibold mb-4">Meta-analysis at a Glance</h2>
             <ul id="stats" class="text-gray-300 space-y-2"></ul>
+        </div>
+        <div class="overflow-x-auto mt-12">
+            <table class="w-full table-auto text-gray-300">
+                <tr>
+                    <td class="px-4 py-2">
+                        <a href="dashboard.html#silent" class="text-indigo-400 hover:underline">Silent VSG Modulation</a>
+                    </td>
+                    <td class="px-4 py-2">
+                        <a href="dashboard.html#main" class="text-red-400 hover:underline">Main VSG Modulation</a>
+                    </td>
+                    <td class="px-4 py-2">
+                        <a href="dashboard.html#qc" class="text-green-400 hover:underline">QC Leaderboard</a>
+                    </td>
+                    <td class="px-4 py-2">
+                        <a href="dashboard.html#table" class="text-purple-400 hover:underline">Experiment Table</a>
+                    </td>
+                </tr>
+            </table>
         </div>
     </div>
     <script src="js/landing.js"></script>


### PR DESCRIPTION
## Summary
- Move analysis links to bottom of landing page and include Main VSG Modulation
- Add Home navigation link to analysis dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bffdce09908331aa84d1398e864617