### PR TITLE
Display VSG modulation tooltips with two decimal precision

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
             div.addEventListener('mouseover', () => {
                 tooltip.style.display = 'block';
                 const title = config.title ? `${config.title}<br>` : '';
-                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}Change: ${item.change.toExponential(4)}`;
+                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}Change: ${item.change.toFixed(2)}`;
             });
             div.addEventListener('mouseout', () => {
                 tooltip.style.display = 'none';

--- a/js/silent.js
+++ b/js/silent.js
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 tooltip.style.display = 'block';
                 const value = item[currentSilentSort];
                 const title = config.title ? `${config.title}<br>` : '';
-                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}${currentSilentSort.toUpperCase()}: ${value.toExponential(4)}`;
+                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}${currentSilentSort.toUpperCase()}: ${value.toFixed(2)}`;
             });
             li.addEventListener('mouseout', () => {
                 tooltip.style.display = 'none';


### PR DESCRIPTION
## Summary
- Show Silent VSG Modulation values in tooltip rounded to two decimals
- Show Main VSG Modulation change values rounded to two decimals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c00cb8844883319980d2758e9a6001