### PR TITLE
Hide QC leaderboard and related links

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -66,7 +66,7 @@
             <a href="index.html" class="nav-link text-gray-400 font-medium pb-1">Home</a>
             <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
             <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
-            <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a>
+        <!-- <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a> -->
             <a href="#" id="nav-table" class="nav-link text-gray-400 font-medium pb-1">Experiment Table</a>
         </nav>
 
@@ -114,7 +114,7 @@
         </div>
 
         <!-- Page 3: QC Leaderboard -->
-        <div id="page-qc" class="page-container">
+        <!-- <div id="page-qc" class="page-container">
             <header class="text-center mb-8">
                 <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-blue-400">
                     QC Visualization
@@ -127,7 +127,7 @@
             </div>
         <div id="qc-leaderboard" class="relative w-full mx-auto max-w-4xl"></div>
         <div id="qc-expander" class="text-center mt-6"></div>
-        </div>
+        </div> -->
         
         <!-- Page 4: Experiment Table -->
         <div id="page-table" class="page-container">
@@ -161,7 +161,7 @@
     <script src="js/common.js"></script>
     <script src="js/silent.js"></script>
     <script src="js/main.js"></script>
-    <script src="js/qc.js"></script>
+    <!-- <script src="js/qc.js"></script> -->
     <script src="js/exp_config_table.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -36,9 +36,9 @@
                     <td class="px-4 py-2">
                         <a href="dashboard.html#main" class="text-red-400 hover:underline">Main VSG Modulation</a>
                     </td>
-                    <td class="px-4 py-2">
-                        <a href="dashboard.html#qc" class="text-green-400 hover:underline">QC Leaderboard</a>
-                    </td>
+        <!-- <td class="px-4 py-2">
+            <a href="dashboard.html#qc" class="text-green-400 hover:underline">QC Leaderboard</a>
+        </td> -->
                     <td class="px-4 py-2">
                         <a href="dashboard.html#table" class="text-purple-400 hover:underline">Experiment Table</a>
                     </td>

--- a/js/common.js
+++ b/js/common.js
@@ -9,15 +9,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const pageTable = document.getElementById('page-table');
 
     function switchPage(page) {
-        [pageSilent, pageMain, pageQC, pageTable].forEach(p => p.classList.remove('active'));
-        [navSilent, navMain, navQC, navTable].forEach(n => n.classList.remove('active'));
+        const pages = [pageSilent, pageMain, pageTable];
+        const navs = [navSilent, navMain, navTable];
+        if (navQC && pageQC) {
+            pages.push(pageQC);
+            navs.push(navQC);
+        }
+        pages.forEach(p => p.classList.remove('active'));
+        navs.forEach(n => n.classList.remove('active'));
         if (page === 'silent') {
             pageSilent.classList.add('active');
             navSilent.classList.add('active');
         } else if (page === 'main') {
             pageMain.classList.add('active');
             navMain.classList.add('active');
-        } else if (page === 'qc') {
+        } else if (page === 'qc' && navQC && pageQC) {
             pageQC.classList.add('active');
             navQC.classList.add('active');
         } else if (page === 'table') {
@@ -28,7 +34,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function handleHash() {
         const hash = window.location.hash.replace('#', '');
-        if (['silent', 'main', 'qc', 'table'].includes(hash)) {
+        const valid = ['silent', 'main', 'table'];
+        if (navQC && pageQC) {
+            valid.push('qc');
+        }
+        if (valid.includes(hash)) {
             switchPage(hash);
         } else {
             switchPage('silent');
@@ -45,10 +55,12 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.hash = 'main';
     });
 
-    navQC.addEventListener('click', (e) => {
-        e.preventDefault();
-        window.location.hash = 'qc';
-    });
+    if (navQC) {
+        navQC.addEventListener('click', (e) => {
+            e.preventDefault();
+            window.location.hash = 'qc';
+        });
+    }
 
     navTable.addEventListener('click', (e) => {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- Hide QC leaderboard link from landing page
- Comment out QC navigation and section on dashboard and remove QC script
- Make common navigation code resilient when QC elements are absent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f3e816b48331b56ccf68e96b7d83