### PR TITLE
Display fold-change and log2 values in silent VSG tooltip

### DIFF
--- a/js/silent.js
+++ b/js/silent.js
@@ -65,7 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 tooltip.style.display = 'block';
                 const value = item[currentSilentSort];
                 const title = config.title ? `${config.title}<br>` : '';
-                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}${currentSilentSort.toUpperCase()}: ${value.toFixed(2)}`;
+                const log2Val = value > 0 ? Math.log2(value) : null;
+                const log2Text = log2Val !== null && isFinite(log2Val) ? log2Val.toFixed(2) : 'N/A';
+                tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title}Fold Change ${currentSilentSort.toUpperCase()}: ${value.toFixed(2)}<br>Log2 Fold Change: ${log2Text}`;
             });
             li.addEventListener('mouseout', () => {
                 tooltip.style.display = 'none';


### PR DESCRIPTION
## Summary
- show "Fold Change" label and log2 fold-change in silent VSG leaderboard tooltips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c403b26854833189273835cb849a22