### PR TITLE
Add scoring clarification to silent leaderboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -77,6 +77,10 @@
                     Trypanosoma Brucei Silent VSGs Modulation
                 </h1>
                 <p class="mt-2 text-lg text-gray-400">Interactive Leaderboard</p>
+                <p class="mt-3 text-base text-gray-400 max-w-3xl mx-auto">
+                    The mean fold change was calculated for all members within each class (BES, MES, MC, array), and the final score
+                    represents the sum of these class-specific mean values.
+                </p>
             </header>
             <div id="filters-silent" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
                 <button data-sort="sum" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Overall Impact (Sum)</button>


### PR DESCRIPTION
## Summary
- add explanatory text under the Silent VSG leaderboard to describe how scores are computed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c93f3416e0833181cec29737312f30