### PR TITLE
Add tooltips for silent leaderboard selectors

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -84,10 +84,10 @@
             </header>
             <div id="filters-silent" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
                 <button data-sort="sum" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Overall Impact (Sum)</button>
-                <button data-sort="BES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">BES</button>
-                <button data-sort="MC" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MC</button>
-                <button data-sort="MES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MES</button>
-                <button data-sort="array" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Array</button>
+                <button data-sort="BES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" title="Bloodstream Expression Site VSGs">BES</button>
+                <button data-sort="MC" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" title="MiniChromosomal VSGs">MC</button>
+                <button data-sort="MES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" title="Metacyclic Expression Site VSGs">MES</button>
+                <button data-sort="array" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" title="Subtelomeric Array VSGs">Array</button>
             </div>
             <div id="leaderboard-container" class="relative w-full mx-auto max-w-4xl"></div>
             <div id="expander-container" class="text-center mt-6"></div>


### PR DESCRIPTION
## Summary
- add descriptive tooltips to the Silent VSG leaderboard filter buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c946a3bd3083318be6603223cdb2fc