### PR TITLE
Fix Silent VSG filter tooltips

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -84,10 +84,10 @@
             </header>
             <div id="filters-silent" class="flex flex-wrap justify-center gap-2 sm:gap-3 mb-8">
                 <button data-sort="sum" class="filter-btn active font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Overall Impact (Sum)</button>
-                <button data-sort="BES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">BES</button>
-                <button data-sort="MC" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MC</button>
-                <button data-sort="MES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">MES</button>
-                <button data-sort="array" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Array</button>
+                <button data-sort="BES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" aria-label="Bloodstream Expression Site VSGs" data-tooltip="<strong>BES</strong><br>Bloodstream Expression Site VSGs">BES</button>
+                <button data-sort="MC" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" aria-label="MiniChromosomal VSGs" data-tooltip="<strong>MC</strong><br>MiniChromosomal VSGs">MC</button>
+                <button data-sort="MES" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" aria-label="Metacyclic Expression Site VSGs" data-tooltip="<strong>MES</strong><br>Metacyclic Expression Site VSGs">MES</button>
+                <button data-sort="array" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700" aria-label="Subtelomeric Array VSGs" data-tooltip="<strong>Array</strong><br>Subtelomeric Array VSGs">Array</button>
             </div>
             <div id="leaderboard-container" class="relative w-full mx-auto max-w-4xl"></div>
             <div id="expander-container" class="text-center mt-6"></div>

--- a/js/silent.js
+++ b/js/silent.js
@@ -7,6 +7,12 @@ document.addEventListener('DOMContentLoaded', () => {
     let silentData = [], currentSilentSort = 'sum', isExpanded = false, expConfig = {};
     const itemHeightSilent = 76, displayLimit = 20;
 
+    const moveTooltip = (event) => {
+        if (!tooltip) return;
+        tooltip.style.left = `${event.clientX + 15}px`;
+        tooltip.style.top = `${event.clientY + 15}px`;
+    };
+
     async function initSilent() {
         try {
             const [csvResp, configResp] = await Promise.all([
@@ -61,19 +67,17 @@ document.addEventListener('DOMContentLoaded', () => {
             if (config.pubmed_id) {
                 link.href = `https://pubmed.ncbi.nlm.nih.gov/${config.pubmed_id}/`;
             }
-            li.addEventListener('mouseover', () => {
+            li.addEventListener('mouseover', (e) => {
                 tooltip.style.display = 'block';
                 const value = item[currentSilentSort];
                 const title = config.title ? `${config.title}<br>` : '';
                 tooltip.innerHTML = `<strong>${item.Experiment}</strong><br>${title} Fold Change ${currentSilentSort.toUpperCase()}: ${value.toFixed(2)}`;
+                moveTooltip(e);
             });
             li.addEventListener('mouseout', () => {
                 tooltip.style.display = 'none';
             });
-            li.addEventListener('mousemove', (e) => {
-                tooltip.style.left = `${e.clientX + 15}px`;
-                tooltip.style.top = `${e.clientY + 15}px`;
-            });
+            li.addEventListener('mousemove', moveTooltip);
             leaderboardContainer.appendChild(li);
         });
     }
@@ -106,6 +110,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 e.target.classList.add('active');
                 renderLeaderboard();
             }
+        });
+
+        filtersSilent.querySelectorAll('button').forEach(button => {
+            const tooltipText = button.dataset.tooltip;
+            if (!tooltipText) return;
+
+            button.addEventListener('mouseenter', (e) => {
+                tooltip.style.display = 'block';
+                tooltip.innerHTML = tooltipText;
+                moveTooltip(e);
+            });
+
+            button.addEventListener('mouseleave', () => {
+                tooltip.style.display = 'none';
+            });
+
+            button.addEventListener('mousemove', moveTooltip);
         });
 
         if (silentData.length > displayLimit) {


### PR DESCRIPTION
## Summary
- add explicit tooltip content and aria labels to the Silent VSG filter buttons
- reuse the existing tooltip element to display abbreviation descriptions when hovering the filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c946a3bd3083318be6603223cdb2fc