### PR TITLE
Add scatter plot visualization page to dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -67,6 +67,7 @@
             <a href="#" id="nav-silent" class="nav-link active text-gray-400 font-medium pb-1">Silent VSG Modulation</a>
             <a href="#" id="nav-main" class="nav-link text-gray-400 font-medium pb-1">Main VSG Modulation</a>
         <!-- <a href="#" id="nav-qc" class="nav-link text-gray-400 font-medium pb-1">QC Leaderboard</a> -->
+            <a href="#" id="nav-scatter" class="nav-link text-gray-400 font-medium pb-1">Scatter Plots</a>
             <a href="#" id="nav-table" class="nav-link text-gray-400 font-medium pb-1">Experiment Table</a>
         </nav>
 
@@ -133,7 +134,35 @@
         <div id="qc-expander" class="text-center mt-6"></div>
         </div> -->
         
-        <!-- Page 4: Experiment Table -->
+        <!-- Page 4: Scatter Plots -->
+        <div id="page-scatter" class="page-container">
+            <header class="text-center mb-8">
+                <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-cyan-400">
+                    Scatter Plots
+                </h1>
+                <p class="mt-2 text-lg text-gray-400">Comparative view of modulation metrics</p>
+            </header>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="bg-gray-800/50 rounded-lg p-4">
+                    <h2 class="text-lg font-semibold text-gray-200 mb-3">BES vs. Main VSG</h2>
+                    <iframe src="scatter_plots/bes_vs_main_vsg.html" title="BES vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                </div>
+                <div class="bg-gray-800/50 rounded-lg p-4">
+                    <h2 class="text-lg font-semibold text-gray-200 mb-3">MES vs. Main VSG</h2>
+                    <iframe src="scatter_plots/MES_vs_main_vsg.html" title="MES vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                </div>
+                <div class="bg-gray-800/50 rounded-lg p-4">
+                    <h2 class="text-lg font-semibold text-gray-200 mb-3">MiniChromosomal vs. Main VSG</h2>
+                    <iframe src="scatter_plots/MC_vs_main_vsg.html" title="MiniChromosomal vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                </div>
+                <div class="bg-gray-800/50 rounded-lg p-4">
+                    <h2 class="text-lg font-semibold text-gray-200 mb-3">Array vs. Main VSG</h2>
+                    <iframe src="scatter_plots/array_vs_main_vsg.html" title="Array vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                </div>
+            </div>
+        </div>
+
+        <!-- Page 5: Experiment Table -->
         <div id="page-table" class="page-container">
             <header class="text-center mb-8">
                 <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-400">

--- a/dashboard.html
+++ b/dashboard.html
@@ -55,6 +55,23 @@
         }
 
         /* Visualization-specific styles moved to external CSS files */
+        .plot-embed {
+            width: 100%;
+            height: 560px;
+            border: 0;
+        }
+
+        @media (min-width: 768px) {
+            .plot-embed {
+                height: 600px;
+            }
+        }
+
+        @media (min-width: 1280px) {
+            .plot-embed {
+                height: 640px;
+            }
+        }
     </style>
 </head>
 <body class="text-white antialiased">
@@ -143,21 +160,21 @@
                 <p class="mt-2 text-lg text-gray-400">Comparative view of modulation metrics</p>
             </header>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div class="bg-gray-800/50 rounded-lg p-4">
+                <div class="bg-gray-800/50 rounded-lg p-4 flex flex-col">
                     <h2 class="text-lg font-semibold text-gray-200 mb-3">BES vs. Main VSG</h2>
-                    <iframe src="scatter_plots/bes_vs_main_vsg.html" title="BES vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                    <iframe src="scatter_plots/bes_vs_main_vsg.html" title="BES vs Main VSG scatter plot" class="plot-embed rounded" loading="lazy"></iframe>
                 </div>
-                <div class="bg-gray-800/50 rounded-lg p-4">
+                <div class="bg-gray-800/50 rounded-lg p-4 flex flex-col">
                     <h2 class="text-lg font-semibold text-gray-200 mb-3">MES vs. Main VSG</h2>
-                    <iframe src="scatter_plots/MES_vs_main_vsg.html" title="MES vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                    <iframe src="scatter_plots/MES_vs_main_vsg.html" title="MES vs Main VSG scatter plot" class="plot-embed rounded" loading="lazy"></iframe>
                 </div>
-                <div class="bg-gray-800/50 rounded-lg p-4">
+                <div class="bg-gray-800/50 rounded-lg p-4 flex flex-col">
                     <h2 class="text-lg font-semibold text-gray-200 mb-3">MiniChromosomal vs. Main VSG</h2>
-                    <iframe src="scatter_plots/MC_vs_main_vsg.html" title="MiniChromosomal vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                    <iframe src="scatter_plots/MC_vs_main_vsg.html" title="MiniChromosomal vs Main VSG scatter plot" class="plot-embed rounded" loading="lazy"></iframe>
                 </div>
-                <div class="bg-gray-800/50 rounded-lg p-4">
+                <div class="bg-gray-800/50 rounded-lg p-4 flex flex-col">
                     <h2 class="text-lg font-semibold text-gray-200 mb-3">Array vs. Main VSG</h2>
-                    <iframe src="scatter_plots/array_vs_main_vsg.html" title="Array vs Main VSG scatter plot" class="w-full h-72 rounded" loading="lazy"></iframe>
+                    <iframe src="scatter_plots/array_vs_main_vsg.html" title="Array vs Main VSG scatter plot" class="plot-embed rounded" loading="lazy"></iframe>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
                     <td class="px-4 py-2">
                         <a href="dashboard.html#main" class="text-red-400 hover:underline">Main VSG Modulation</a>
                     </td>
+                    <td class="px-4 py-2">
+                        <a href="dashboard.html#scatter" class="text-emerald-400 hover:underline">Scatter Plots</a>
+                    </td>
         <!-- <td class="px-4 py-2">
             <a href="dashboard.html#qc" class="text-green-400 hover:underline">QC Leaderboard</a>
         </td> -->

--- a/js/common.js
+++ b/js/common.js
@@ -2,15 +2,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const navSilent = document.getElementById('nav-silent');
     const navMain = document.getElementById('nav-main');
     const navQC = document.getElementById('nav-qc');
+    const navScatter = document.getElementById('nav-scatter');
     const navTable = document.getElementById('nav-table');
     const pageSilent = document.getElementById('page-silent');
     const pageMain = document.getElementById('page-main');
     const pageQC = document.getElementById('page-qc');
+    const pageScatter = document.getElementById('page-scatter');
     const pageTable = document.getElementById('page-table');
 
     function switchPage(page) {
-        const pages = [pageSilent, pageMain, pageTable];
-        const navs = [navSilent, navMain, navTable];
+        const pages = [pageSilent, pageMain, pageScatter, pageTable];
+        const navs = [navSilent, navMain, navScatter, navTable];
         if (navQC && pageQC) {
             pages.push(pageQC);
             navs.push(navQC);
@@ -23,6 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (page === 'main') {
             pageMain.classList.add('active');
             navMain.classList.add('active');
+        } else if (page === 'scatter') {
+            pageScatter.classList.add('active');
+            navScatter.classList.add('active');
         } else if (page === 'qc' && navQC && pageQC) {
             pageQC.classList.add('active');
             navQC.classList.add('active');
@@ -34,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function handleHash() {
         const hash = window.location.hash.replace('#', '');
-        const valid = ['silent', 'main', 'table'];
+        const valid = ['silent', 'main', 'scatter', 'table'];
         if (navQC && pageQC) {
             valid.push('qc');
         }
@@ -53,6 +58,11 @@ document.addEventListener('DOMContentLoaded', () => {
     navMain.addEventListener('click', (e) => {
         e.preventDefault();
         window.location.hash = 'main';
+    });
+
+    navScatter.addEventListener('click', (e) => {
+        e.preventDefault();
+        window.location.hash = 'scatter';
     });
 
     if (navQC) {


### PR DESCRIPTION
## Summary
- add a Scatter Plots navigation link and page with a 2x2 grid embedding the four Plotly scatter plots
- update the shared navigation script to activate the new Scatter Plots route
- expose the Scatter Plots page from the main landing page shortcuts

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d7dcbda7848331a3450e08d5c50286