### PR TITLE
Add ±3.1 limit markers to main VSG chart

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -8,6 +8,7 @@ textarea {
 
 #chart-container {
     transition: height 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    padding-bottom: 1.5rem;
 }
 .chart-item {
     position: absolute;
@@ -17,6 +18,7 @@ textarea {
     align-items: center;
     transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
     will-change: transform;
+    z-index: 2;
 }
 .diverging-bar {
     position: absolute;
@@ -41,6 +43,34 @@ textarea {
     bottom: 0;
     width: 2px;
     background-color: #4b5563; /* bg-gray-600 */
+    z-index: 1;
+    pointer-events: none;
+}
+.axis-limit {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #6b7280; /* bg-gray-500 */
+    opacity: 0.7;
+    pointer-events: none;
+    z-index: 1;
+}
+.axis-limit-left {
+    left: 0;
+}
+.axis-limit-right {
+    right: 0;
+}
+.axis-limit-label {
+    position: absolute;
+    bottom: -1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    color: #9ca3af; /* text-gray-400 */
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
 }
 .item-label {
     position: absolute;

--- a/css/main.css
+++ b/css/main.css
@@ -8,7 +8,7 @@ textarea {
 
 #chart-container {
     transition: height 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-    padding: 1.5rem 0 3rem;
+    padding: 1.5rem 0 1.5rem;
 }
 .chart-item {
     position: absolute;
@@ -55,9 +55,6 @@ textarea {
     pointer-events: none;
     z-index: 1;
 }
-.axis-baseline-bottom {
-    bottom: 0;
-}
 .axis-baseline-top {
     top: 0.5rem;
 }
@@ -67,9 +64,6 @@ textarea {
     color: #9ca3af; /* text-gray-400 */
     letter-spacing: 0.05em;
     text-transform: uppercase;
-}
-.axis-baseline-bottom .axis-baseline-label {
-    bottom: calc(100% + 0.25rem);
 }
 .axis-baseline-top .axis-baseline-label {
     top: calc(100% + 0.25rem);

--- a/css/main.css
+++ b/css/main.css
@@ -8,7 +8,7 @@ textarea {
 
 #chart-container {
     transition: height 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-    padding-bottom: 1.5rem;
+    padding: 1.5rem 0;
 }
 .chart-item {
     position: absolute;
@@ -50,19 +50,29 @@ textarea {
     position: absolute;
     left: 0;
     right: 0;
-    bottom: 0.5rem;
     height: 2px;
     background: linear-gradient(90deg, rgba(107, 114, 128, 0.1), rgba(107, 114, 128, 0.7), rgba(107, 114, 128, 0.1));
     pointer-events: none;
     z-index: 1;
 }
+.axis-baseline-bottom {
+    bottom: 0.5rem;
+}
+.axis-baseline-top {
+    top: 0.5rem;
+}
 .axis-baseline-label {
     position: absolute;
-    bottom: -1.25rem;
     font-size: 0.75rem;
     color: #9ca3af; /* text-gray-400 */
     letter-spacing: 0.05em;
     text-transform: uppercase;
+}
+.axis-baseline-bottom .axis-baseline-label {
+    bottom: calc(100% + 0.25rem);
+}
+.axis-baseline-top .axis-baseline-label {
+    top: calc(100% + 0.25rem);
 }
 .axis-baseline-label-left {
     left: 0;

--- a/css/main.css
+++ b/css/main.css
@@ -46,31 +46,32 @@ textarea {
     z-index: 1;
     pointer-events: none;
 }
-.axis-limit {
+.axis-baseline {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 2px;
-    background-color: #6b7280; /* bg-gray-500 */
-    opacity: 0.7;
+    left: 0;
+    right: 0;
+    bottom: 0.5rem;
+    height: 2px;
+    background: linear-gradient(90deg, rgba(107, 114, 128, 0.1), rgba(107, 114, 128, 0.7), rgba(107, 114, 128, 0.1));
     pointer-events: none;
     z-index: 1;
 }
-.axis-limit-left {
-    left: 0;
-}
-.axis-limit-right {
-    right: 0;
-}
-.axis-limit-label {
+.axis-baseline-label {
     position: absolute;
-    bottom: -1.5rem;
-    left: 50%;
-    transform: translateX(-50%);
+    bottom: -1.25rem;
     font-size: 0.75rem;
     color: #9ca3af; /* text-gray-400 */
     letter-spacing: 0.05em;
     text-transform: uppercase;
+}
+.axis-baseline-label-left {
+    left: 0;
+    transform: translateX(-10%);
+}
+.axis-baseline-label-right {
+    right: 0;
+    transform: translateX(10%);
+    text-align: right;
 }
 .item-label {
     position: absolute;

--- a/css/main.css
+++ b/css/main.css
@@ -8,7 +8,7 @@ textarea {
 
 #chart-container {
     transition: height 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-    padding: 1.5rem 0;
+    padding: 1.5rem 0 3rem;
 }
 .chart-item {
     position: absolute;
@@ -56,7 +56,7 @@ textarea {
     z-index: 1;
 }
 .axis-baseline-bottom {
-    bottom: 0.5rem;
+    bottom: 0;
 }
 .axis-baseline-top {
     top: 0.5rem;

--- a/dashboard.html
+++ b/dashboard.html
@@ -130,11 +130,9 @@
                     <span>Up-regulated</span>
                 </div>
                 <div id="chart-container" class="relative w-full">
-                    <div class="axis-limit axis-limit-left" aria-hidden="true">
-                        <span class="axis-limit-label">-3.1</span>
-                    </div>
-                    <div class="axis-limit axis-limit-right" aria-hidden="true">
-                        <span class="axis-limit-label">+3.1</span>
+                    <div class="axis-baseline" aria-hidden="true">
+                        <span class="axis-baseline-label axis-baseline-label-left">-3.1</span>
+                        <span class="axis-baseline-label axis-baseline-label-right">+3.1</span>
                     </div>
                     <div class="center-axis" aria-hidden="true"></div>
                 </div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -130,7 +130,13 @@
                     <span>Up-regulated</span>
                 </div>
                 <div id="chart-container" class="relative w-full">
-                    <div class="center-axis"></div>
+                    <div class="axis-limit axis-limit-left" aria-hidden="true">
+                        <span class="axis-limit-label">-3.1</span>
+                    </div>
+                    <div class="axis-limit axis-limit-right" aria-hidden="true">
+                        <span class="axis-limit-label">+3.1</span>
+                    </div>
+                    <div class="center-axis" aria-hidden="true"></div>
                 </div>
             </div>
         </div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -134,10 +134,6 @@
                         <span class="axis-baseline-label axis-baseline-label-left">-3.1</span>
                         <span class="axis-baseline-label axis-baseline-label-right">+3.1</span>
                     </div>
-                    <div class="axis-baseline axis-baseline-bottom" aria-hidden="true">
-                        <span class="axis-baseline-label axis-baseline-label-left">-3.1</span>
-                        <span class="axis-baseline-label axis-baseline-label-right">+3.1</span>
-                    </div>
                     <div class="center-axis" aria-hidden="true"></div>
                 </div>
             </div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -130,7 +130,11 @@
                     <span>Up-regulated</span>
                 </div>
                 <div id="chart-container" class="relative w-full">
-                    <div class="axis-baseline" aria-hidden="true">
+                    <div class="axis-baseline axis-baseline-top" aria-hidden="true">
+                        <span class="axis-baseline-label axis-baseline-label-left">-3.1</span>
+                        <span class="axis-baseline-label axis-baseline-label-right">+3.1</span>
+                    </div>
+                    <div class="axis-baseline axis-baseline-bottom" aria-hidden="true">
                         <span class="axis-baseline-label axis-baseline-label-left">-3.1</span>
                         <span class="axis-baseline-label axis-baseline-label-right">+3.1</span>
                     </div>


### PR DESCRIPTION
## Summary
- add visual limit markers to the Main VSG diverging chart to highlight the ±3.1 range
- style the new markers and labels while reserving space beneath the chart for the captions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e28a1101248331b43d597f6091a754