### PR TITLE
Add central Log2 Fold Change label to main VSG modulation chart

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -55,6 +55,14 @@ textarea {
     pointer-events: none;
     z-index: 1;
 }
+.axis-mid-label {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    pointer-events: none;
+    font-weight: 600;
+    color: #d1d5db; /* text-gray-300 */
+}
 .axis-baseline-top {
     top: 0.5rem;
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -125,8 +125,9 @@
                 <button data-sort="down" class="filter-btn font-semibold py-2 px-4 rounded-full bg-gray-800 hover:bg-gray-700">Top Down-regulated</button>
             </div>
             <div class="relative w-full bg-gray-800/50 rounded-lg p-4 sm:p-6">
-                <div class="flex justify-between text-xs text-gray-400 mb-2 px-2">
+            <div class="flex justify-between text-xs text-gray-400 mb-2 px-2 relative">
                     <span>Down-regulated</span>
+                    <span class="axis-mid-label">Log2 Fold Change</span>
                     <span>Up-regulated</span>
                 </div>
                 <div id="chart-container" class="relative w-full">


### PR DESCRIPTION
## Summary
- add a central "Log2 Fold Change" label between the Down- and Up-regulated axis labels
- style the new axis label so it sits over the intersection of the vertical and horizontal guides

## Testing
- Manually verified in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e291d85c7883318a3e55db12d2e6a8